### PR TITLE
don't define mon_host if mon_host is overridden

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chris.jones@lambdastack.io'
 license 'Apache v2.0'
 description 'Installs/Configures Ceph (Jewel and above)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.24'
+version '1.1.25'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'

--- a/templates/default/ceph.conf.erb
+++ b/templates/default/ceph.conf.erb
@@ -21,7 +21,7 @@
   # to the cluster and public network options since they are all critical to every node.
   # List of all of the monitor nodes in the given cluster
   <% #Check ALL of the important vars before modifying them just in case their values are empty or nil. -%>
-  <% if !@mon_addresses.nil? && !@mon_addresses.empty? -%>
+  <% if !@mon_addresses.nil? && !@mon_addresses.empty? && !node['ceph']['config']['global']['mon_host'].nil? -%>
   mon host = <%= @mon_addresses.sort.join(', ') %>
   <% end -%>
   # Suppress warning of too many pgs


### PR DESCRIPTION
We need to override the default addresses for ceph mons